### PR TITLE
Reduce motion in auto-scroll of NS charts for new BG readings and zoo…

### DIFF
--- a/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Charts/NightscoutChart/NightscoutChartView.swift
@@ -37,13 +37,6 @@ struct NightscoutChartScrollView: View {
                         .padding([.top, .bottom]) //Prevent top Y label from clipping
                         .id(configuration.graphTag)
                         .modifier(PinchToZoom(minScale: minScale, maxScale: maxScale, scale: $currentScale))
-                        .onChange(of: currentScale) { newValue in
-                            scrollReaderProxy.scrollTo(configuration.graphTag, anchor: .trailing)
-                        }
-                        //TODO clean up scrolling to land at a nice place so you see mostly real BGs and ~1h of predicted BGs
-                        .onChange(of: remoteDataSource.glucoseSamples, perform: { newValue in
-                            scrollReaderProxy.scrollTo(configuration.graphTag, anchor: .trailing)
-                        })
                         //TODO clean up scrolling to land at a nice place so you see mostly real BGs and ~1h of predicted BGs
                         .onAppear(perform: {
                             scrollReaderProxy.scrollTo(configuration.graphTag, anchor: .trailing)


### PR DESCRIPTION
…m changes

*Stop scrolling when a new reading comes in - when you are zoomed in to look at a detail in the past, and a new reading comes in, the last thing you want to do is lose where you were and have to manually find it again

*Stop scrolling on zoom change - when a user zooms in to an area, they are better off being left closer to their zoom location rather than shifting to the far right (end) of the graph on zoom, and manually scrolling back to find their prior spot

*Not done: would still be nice to change the onAppear zoom location to be ~75% history and ~25% future